### PR TITLE
Convert all latex format to mathjax latex format

### DIFF
--- a/org-anki.el
+++ b/org-anki.el
@@ -129,11 +129,26 @@ with result."
 
 (cl-defstruct org-anki--note maybe-id front back tags deck point)
 
+(defun org-anki-back-post-processing (text)
+  (org-anki-string-to-anki-mathjax text)
+  )
+
+(defun org-anki-string-to-anki-mathjax (latex-code)
+  (let ((delimiter-map (list (cons (regexp-quote "\\begin{equation}") "\\\\[")
+                             (cons (regexp-quote "\\end{equation}") "\\\\]")
+                             (cons (regexp-quote "\\begin{align}") "\\\\[\n\\\\begin{aligned}")
+                             (cons (regexp-quote "\\end{align}") "\\\\end{aligned}\n\\\\]")))
+        (matched nil))
+    (dolist (delimiter delimiter-map)
+      (setq latex-code (replace-regexp-in-string (car delimiter) (cdr delimiter) latex-code))))
+  latex-code
+  )
+
 (defun org-anki--note-at-point ()
   (let
       ((front (org-anki--string-to-html (org-entry-get nil "ITEM")))
        (note-start (point))
-       (back (org-anki--string-to-html (org-anki--entry-content-until-any-heading)))
+       (back (org-anki-back-post-processing (org-anki--string-to-html (org-anki--entry-content-until-any-heading))))
        (tags (org-anki--get-tags))
        (deck (org-anki--find-deck))
        (maybe-id (org-entry-get nil org-anki-prop-note-id)))


### PR DESCRIPTION
Converting all latex environments to be compatible with the Mathjax format used by Anki cards, including single line and multi-line equations.

For example, when the following equations are in the org-mode:
```
\begin{equation}
a^2+b^=\frac{1}{\sqrt{c}}
\end{equation}

\begin{align}
a^2+b^2&=\frac{1}{\sqrt{c}}\\
a+b&=c
\end{align}
```
They are converted to the following HTML codes in anki:
```
\[
a^2+b^=\frac{1}{\sqrt{c}}
\]

\[
\begin{aligned}
a^2+b^2&amp;=\frac{1}{\sqrt{c}}\\
a+b&amp;=c
\end{aligned}
\]
```
which are rendered correctly by the default anki configurations.

![image](https://user-images.githubusercontent.com/4384206/134605718-80ac1a82-dd5b-400b-9b7b-68111e378b55.png)

