### PR TITLE
Inherit ANKI_DECK property

### DIFF
--- a/org-anki.el
+++ b/org-anki.el
@@ -249,7 +249,7 @@ question and answer are generated from it, and BACK is ignored."
 
 (defun org-anki--find-deck ()
   (thunk-let
-   ((prop-item (org-entry-get nil org-anki-prop-deck))
+   ((prop-item (org-entry-get nil org-anki-prop-deck t))
     (prop-global (org-anki--get-global-prop org-anki-prop-deck)))
     (cond
      ((stringp prop-item) prop-item)


### PR DESCRIPTION
# Description
Before, in order to add cards to multiple decks in a single file we would need to define `ANKI_DECK` in every card. This PR makes it so the `ANKI_DECK` property can be inherited.

## Example
Cards 1 and 2 would be added to the `SomeBook::Chapter1` deck, while cards 3 and 4 would be added to `SomeBook::Chapter2`. 
```
#+TITLE: Some book
#+ANKI_MATCH: card

* Chapter 1
:PROPERTIES:
:ANKI_DECK: SomeBook::Chapter1
:END:

** Card 1 :card:
Card 1 back

** Card 2 :card:
Card 2 back

* Chapter 2
:PROPERTIES:
:ANKI_DECK: SomeBook::Chapter2
:END:

** Card 3 :card:
Card 3 back

** Card 4 :card:
Card 4 back
```