### PR TITLE
Change what counts as cloze

### DIFF
--- a/org-anki.el
+++ b/org-anki.el
@@ -320,8 +320,7 @@ ignored."
 
 (defun org-anki--is-cloze (text)
   "Check if TEXT has cloze syntax, return nil if not."
-  ;; Check for something similar to {{c1::Hidden-text::Hint}} in TEXT
-  (if (string-match "{{c[0-9]+::\\([^:\}]*\\)::\\([^:\}]*\\)}}" text)
+  (if (string-match "{{c[0-9]+::.*}}" text)
       "Cloze"
     nil))
 


### PR DESCRIPTION
I never use hints in my cloze deletions, so when using org-anki a card like the one from [ankidocs](https://docs.ankiweb.net/editing.html#cloze-deletion): "{{c1::Canberra was founded}} in 1913" would be Basic instead of Cloze after running org-anki-sync-entry. I notice you omit colons and } in the [] but it would be valid cloze in anki to have something like "text {{c1::text:}{te:xt}}". To not support that is not a big deal, but the main thing is supporting the syntax above. In case you think this regexp is a bit too broad and may clash with something else without omitting the : and } in [], perhaps just take the original and replace the 2nd `::` with `\\(::\\)?` to make the hint optional.