### PR TITLE
Add improved MR "Change what counts as cloze" #34

### DIFF
--- a/org-anki.el
+++ b/org-anki.el
@@ -321,7 +321,7 @@ ignored."
 (defun org-anki--is-cloze (text)
   "Check if TEXT has cloze syntax, return nil if not."
   ;; Check for something similar to {{c1::Hidden-text::Hint}} in TEXT
-  (if (string-match "{{c[0-9]+::\\([^:\}]*\\)::\\([^:\}]*\\)}}" text)
+  (if (string-match "{{c[0-9]+::\\(\n\\|.\\)*}}" text)
       "Cloze"
     nil))
 


### PR DESCRIPTION
This adds the \n alternative to the dot in the original MR because as
cloze can come from an org entry's body text then it can be multiline.