### PR TITLE
Images draft

### DIFF
--- a/org-anki.el
+++ b/org-anki.el
@@ -94,6 +94,11 @@ how to use it to include or skip an entry from being synced."
   :type '(function)
   :group 'org-anki)
 
+(defcustom org-anki-media-path nil
+  "Path to Anki's media collection, set to nil to turn off copying media."
+  :type '(string)
+  :group 'org-anki)
+
 ;; Stolen code
 
 ;; Get list of global properties

--- a/org-anki.el
+++ b/org-anki.el
@@ -688,9 +688,7 @@ Pandoc is required to be installed."
 
 (defun org-anki--remove-media-prefix(node)
   (let* ((path (org-ml-get-property :path node))
-		 (new-path (string-remove-prefix
-					(concat (directory-file-name org-anki-media-dir) "/")
-					path)))
+		 (new-path (file-name-nondirectory path)))
 			 (org-ml-set-property :path new-path node)))
 
 

--- a/org-anki.el
+++ b/org-anki.el
@@ -36,6 +36,7 @@
 (require 'json)
 (require 'org)
 (require 'org-element)
+(require 'org-ml)
 (require 'promise)
 (require 'request)
 (require 'thunk)
@@ -674,11 +675,25 @@ Pandoc is required to be installed."
 
 (defun org-anki--html-to-org (html)
   (if html
-      (replace-regexp-in-string
-       "\n+$" ""
-       (shell-command-to-string
-        (format "pandoc --wrap=none --from=html --to=org <<< %s" (shell-quote-argument html))))
+	  (add-link-prefix
+       (replace-regexp-in-string
+		"\n+$" ""
+		(shell-command-to-string
+         (format "pandoc --wrap=none --from=html --to=org <<< %s" (shell-quote-argument html)))))
     ""))
+
+
+(defun add-link-prefix (org-string)
+  (->> (org-ml--from-string org-string)
+	   (org-ml-match-map '(:any * (:and link))
+		 (lambda (node)
+		   (let* ((path (org-ml-get-property :path node))
+				  (new-path (concat anki-org--media-path path))) ;; fix this
+			 (org-ml-set-property :path new-path node))))
+	   (org-ml-to-string)))
+
+(setq anki-org--media-path "~/anki2-docker-2.1.40/User 1/collection.media/")
+
 
 (defun org-anki--write-note (note)
   ;; Add title

--- a/org-anki.el
+++ b/org-anki.el
@@ -732,5 +732,15 @@ Pandoc is required to be installed."
           (insert content)
           (insert "\n")))))
 
+(defun org-anki-copy-images ()
+  ;; todo: filter non images (or at least non files)
+  ;; todo: make image names unique?
+  (interactive)
+  (->> (org-ml-parse-this-subtree)
+	   (org-ml-match '(:any * link))
+	   (--map (org-ml-get-property :path it))
+	   (--remove (string-prefix-p org-anki-media-dir it))
+	   (--map (copy-file it org-anki-media-dir t))))
+
 (provide 'org-anki)
 ;;; org-anki.el ends here

--- a/org-anki.el
+++ b/org-anki.el
@@ -308,7 +308,7 @@ ignored."
 (defun org-anki--string-to-html (string)
   "Convert STRING (org element heading or content) to html."
   (save-excursion (org-export-string-as
-				   (org-anki--edit-links 'org-anki--remove-prefix string)
+				   (org-anki--edit-links 'org-anki--remove-media-prefix string)
 				   'html t '(:with-toc nil))))
 
 (defun org-anki--report-error (format error)
@@ -680,15 +680,17 @@ Pandoc is required to be installed."
      :point    nil))))
 
 
-(defun org-anki--add-prefix(node)
+(defun org-anki--add-media-prefix(node)
   (let* ((path (org-ml-get-property :path node))
-		 (new-path (concat org-anki--media-path path))) ;; fix this
+		 (new-path (expand-file-name path org-anki-media-dir)))
 	(org-ml-set-property :path new-path node)))
 
 
-(defun org-anki--remove-prefix(node)
+(defun org-anki--remove-media-prefix(node)
   (let* ((path (org-ml-get-property :path node))
-				  (new-path (string-remove-prefix org-anki--media-path path))) ;; fix this
+		 (new-path (string-remove-prefix
+					(concat (directory-file-name org-anki-media-dir) "/")
+					path)))
 			 (org-ml-set-property :path new-path node)))
 
 
@@ -700,7 +702,7 @@ Pandoc is required to be installed."
 
 (defun org-anki--html-to-org (html)
   (if html
-	  (org-anki--edit-links 'org-anki--add-prefix
+	  (org-anki--edit-links 'org-anki--add-media-prefix
        (replace-regexp-in-string
 		"\n+$" ""
 		(shell-command-to-string

--- a/org-anki.el
+++ b/org-anki.el
@@ -675,6 +675,24 @@ Pandoc is required to be installed."
      :point    nil))))
 
 
+(defun org-anki--add-prefix(node)
+  (let* ((path (org-ml-get-property :path node))
+		 (new-path (concat org-anki--media-path path))) ;; fix this
+	(org-ml-set-property :path new-path node)))
+
+
+(defun org-anki--remove-prefix(node)
+  (let* ((path (org-ml-get-property :path node))
+				  (new-path (string-remove-prefix org-anki--media-path path))) ;; fix this
+			 (org-ml-set-property :path new-path node)))
+
+
+(defun org-anki--edit-links (func org-string)
+  (->> (org-ml--from-string org-string)
+	   (org-ml-match-map '(:any * (:and link)) func)
+	   (org-ml-to-string)))
+
+
 (defun org-anki--html-to-org (html)
   (if html
 	  (org-anki--edit-links 'org-anki--add-prefix
@@ -683,25 +701,6 @@ Pandoc is required to be installed."
 		(shell-command-to-string
          (format "pandoc --wrap=none --from=html --to=org <<< %s" (shell-quote-argument html)))))
     ""))
-
-
-(defun org-anki--add-prefix(node)
-  (let* ((path (org-ml-get-property :path node))
-		 (new-path (concat anki-org--media-path path))) ;; fix this
-	(org-ml-set-property :path new-path node)))
-
-(defun org-anki--remove-prefix(node)
-  (let* ((path (org-ml-get-property :path node))
-				  (new-path (string-remove-prefix anki-org--media path))) ;; fix this
-			 (org-ml-set-property :path new-path node)))
-
-(defun org-anki--edit-links (func org-string)
-  (->> (org-ml--from-string org-string)
-	   (org-ml-match-map '(:any * (:and link)) func)
-	   (org-ml-to-string)))
-
-
-(setq org-anki--media-path "~/anki2-docker-2.1.40/User 1/collection.media/")
 
 
 (defun org-anki--write-note (note)

--- a/org-anki.el
+++ b/org-anki.el
@@ -733,11 +733,13 @@ Pandoc is required to be installed."
           (insert "\n")))))
 
 (defun org-anki-copy-images ()
-  ;; todo: filter non images (or at least non files)
+  ;; todo: add variables to filter file extensions
   ;; todo: make image names unique?
   (interactive)
   (->> (org-ml-parse-this-subtree)
 	   (org-ml-match '(:any * link))
+	   (--filter (string= (org-ml-get-property :type it)
+						  "file"))
 	   (--map (org-ml-get-property :path it))
 	   (--remove (string-prefix-p org-anki-media-dir it))
 	   (--map (copy-file it org-anki-media-dir t))))

--- a/org-anki.el
+++ b/org-anki.el
@@ -6,7 +6,7 @@
 ;; Version: 1.0.4
 ;; Author: Markus Läll <markus.l2ll@gmail.com>
 ;; Keywords: outlines, flashcards, memory
-;; Package-Requires: ((emacs "27.1") (request "0.3.2") (dash "2.17") (promise "1.1"))
+;; Package-Requires: ((emacs "27.1") (request "0.3.2") (dash "2.17") (promise "1.1") (org-ml "5.8.1"))
 
 ;; This file is free software; you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by

--- a/org-anki.el
+++ b/org-anki.el
@@ -696,7 +696,7 @@ Pandoc is required to be installed."
 
 (defun org-anki--edit-links (func org-string)
   (->> (org-ml--from-string org-string)
-	   (org-ml-match-map '(:any * (:and link)) func)
+	   (org-ml-match-map '(:any * link) func)
 	   (org-ml-to-string)))
 
 


### PR DESCRIPTION
Hi!

I hacked a bit on a solution to integrate images from org into anki notes and vice-versa. It still has a few rough edges and I didn't try it out much yet. But it reached a point where at least for me it seems to work fine. I wanted to share it so other can try it out and comment the code and usage.

The general idea is the following. Media are stored in a special folder under the Anki dir. To sync with AnkiWeb the media need to be there, it seems not possible to use links. So for the direction org->anki we need to copy the images to the media dir of anki. Also we need to strip of the local path before the image name in the org links. For the anki->org direction we can just directly point to the media dir of anki. This is used when importing a deck that already had images.

Concretely I added the following:
- a custom variable `org-anki-media-dir` which points to where anki stores media.
- anki->org: in `org-anki--html-to-org` I wrapped the output string to add `org-anki-media-dir` as a prefix to all links. This relies on `org-ml` for now, not sure if you want to add this dependency.
- org->anki: in `org-anki--string-to-html` I wrapped the string to remove the folder from all links. Also relies on `org-ml`
- org-anki: I added a function `org-anki-copy-images` which copies all the images from links under the subtree at point (this could be changed) to anki media dir. This also relies on org-ml.

What do you think about adding `org-ml` as a new dependency? I feel more comfortable using this than direct string insertion.

WDYT?