### PR TITLE
Add skip function to sync-all

### DIFF
--- a/org-anki.el
+++ b/org-anki.el
@@ -86,6 +86,12 @@ property"
   :type 'boolean
   :group 'org-anki)
 
+(defcustom org-anki-skip-funktion nil
+  "Function used to skip tags.
+Should behave like org-agenda-skip-function."
+  :type '(function)
+  :group 'org-anki)
+
 ;; Stolen code
 
 ;; Get list of global properties
@@ -538,7 +544,7 @@ ignored."
   (interactive)
   (with-current-buffer (or buffer (buffer-name))
     (org-anki--sync-notes
-     (org-map-entries 'org-anki--note-at-point (org-anki--get-match)))))
+     (org-map-entries 'org-anki--note-at-point (org-anki--get-match) nil 'org-anki-skip-function))))
 
 ;;;###autoload
 (defun org-anki-update-all (&optional buffer)


### PR DESCRIPTION
This allows users to skip some headlines using a more complex filtering mechanism than the tags/property/todo match.