### PR TITLE
Handle errors when adding notes.

### DIFF
--- a/org-anki.el
+++ b/org-anki.el
@@ -387,13 +387,20 @@ ignored."
       ((note-with-action (car pair))
        (note (car note-with-action))
        (action (cdr note-with-action))
-       (result (car (cdr pair))))
+       (result (car (cdr pair)))
+       (error-msg (and (listp result)
+                       (assoc-default 'error result))))
     (cond
      ;; added note
      ((equal "addNote" (assoc-default "action" action))
-      (save-excursion
-        (goto-char (org-anki--note-point note))
-        (org-set-property org-anki-prop-note-id (number-to-string result))))
+      (if (or (not error-msg)
+              (string= "" error-msg))
+          (save-excursion
+            (goto-char (org-anki--note-point note))
+            (org-set-property org-anki-prop-note-id (number-to-string result)))
+        (org-anki--report-error
+         "Couldn't add note, received error: %s"
+         error-msg)))
      ;; update note
      ((equal "updateNoteFields" (assoc-default "action" action))
       (message "org-anki: note succesfully updated: %s" (org-anki--note-maybe-id note))))))


### PR DESCRIPTION
Hi,

Occasionally, `M-x org-anki-sync-all` didn't work properly, the note id may not be added but the entry was created in Anki. And then there would be an error when I `M-x org-anki-sync-entry` again, the backtrace was:

```
Debugger entered--Lisp error: (wrong-type-argument numberp ((result) (error . "cannot create note because it is a duplicate")))
  number-to-string(((result) (error . "cannot create note because it is a duplicate")))
  (org-set-property org-anki-prop-note-id (number-to-string result))
  (save-excursion (goto-char (progn (or (progn (and (memq (type-of note) cl-struct-org-anki--note-tags) t)) (signal 'wrong-type-argument (list 'org-anki--note note))) (aref note 7))) (org-set-property org-anki-prop-note-id (number-to-string result)))
...
...
```

The corresponding HTTP response was like:
```
HTTP/1.1 200 OK
Content-Type: text/json
Access-Control-Allow-Origin: http://localhost
Access-Control-Allow-Headers: *
Content-Length: 102

{
  "result": [
    {
      "result": null,
      "error": "cannot create note because it is a duplicate"
    }
  ],
  "error": null
}
```

While a normal response was like:
```
HTTP/1.1 200 OK
Content-Type: text/json
Access-Control-Allow-Origin: http://localhost
Access-Control-Allow-Headers: *
Content-Length: 42

{"result": [1669997809252], "error": null}
```

This tries to fix this case based on the above HTTP responses.