### PR TITLE
Field templating

### DIFF
--- a/org-anki.el
+++ b/org-anki.el
@@ -3,7 +3,7 @@
 ;; Copyright (C) 2020 Markus Läll
 ;;
 ;; URL: https://github.com/eyeinsky/org-anki
-;; Version: 2.0.1
+;; Version: 3.0.0
 ;; Author: Markus Läll <markus.l2ll@gmail.com>
 ;; Keywords: outlines, flashcards, memory
 ;; Package-Requires: ((emacs "27.1") (request "0.3.2") (dash "2.17") (promise "1.1"))

--- a/org-anki.el
+++ b/org-anki.el
@@ -1,6 +1,6 @@
 ;;; org-anki.el --- Synchronize org-mode entries to Anki -*- lexical-binding: t -*-
 ;;
-;; Copyright (C) 2022 Markus Läll
+;; Copyright (C) 2020 Markus Läll
 ;;
 ;; URL: https://github.com/eyeinsky/org-anki
 ;; Version: 2.0.1


### PR DESCRIPTION
Attempting to solve adding backlinks issue: https://github.com/eyeinsky/org-anki/issues/18

One can now do:
```
(customize-set-variable
 'org-anki-field-templates
 '(("Basic"
    ("Back" . (lambda (it)
                (let ((path (buffer-file-name)))
                  (concat it (format "<p><a href='%s'>%s</a></p>" path path))))))))
```
to add a backlink or any other content to the field value. (The `it` in the lambda is the original string, and the backlink html is concatenated to the end of it.)

@panmengguan, @hwiorn Please test if you feel like it :) 
