### PR TITLE
fix the problem that some ANKI_NOTE_IDs could be missing

### DIFF
--- a/org-anki.el
+++ b/org-anki.el
@@ -201,7 +201,7 @@ with result."
    fields))
 
 (defun org-anki--note-at-point ()
-  "Create an Anki note from whereever the cursor is"
+  "Create an Anki note from wherever the cursor is."
   ;; :: IO Note
   (-let*
       ((maybe-id (org-entry-get nil org-anki-prop-note-id))
@@ -555,7 +555,7 @@ be removed from the Anki app, return actions that do that."
 
            (if (and (= (length updates) 1) (= (length notes) 1))
 
-               ;; If there there is only one update, then don't use
+               ;; If there is only one update, then don't use
                ;; multi for that:
                (let* ((pair (car updates))
                       (note (car pair))
@@ -576,7 +576,7 @@ be removed from the Anki app, return actions that do that."
                  (if notes-and-tag-actions2
                      (org-anki--execute-api-actions notes-and-tag-actions2)))
 
-             ;; It's not just one updated note, default to multi;; hit this branch
+             ;; It's not just one updated note, default to multi
              (let ((note-action-pairs (-concat additions updates notes-and-tag-actions2))) ;; [(Note, Action)]
                (org-anki--execute-api-actions note-action-pairs))))))
       (promise-catch (lambda (reason) (error reason))))))

--- a/org-anki.el
+++ b/org-anki.el
@@ -647,7 +647,7 @@ Updates all entries that have ANKI_NOTE_ID property set."
   (interactive)
   (with-current-buffer (or buffer (buffer-name))
     (org-anki--sync-notes
-     (org-map-entries 'org-anki--note-at-point "ANKI_NOTE_ID<>\"\""))))
+     (org-map-entries 'org-anki--note-at-point (conat org-anki-prop-note-id "<>\"\"")))))
 
 ;;;###autoload
 (defun org-anki-delete-entry ()
@@ -668,7 +668,7 @@ Updates all entries that have ANKI_NOTE_ID property set."
     (if (y-or-n-p prompt)
         (with-current-buffer buffer-name_
           (org-anki--delete-notes_
-           (org-map-entries 'org-anki--note-at-point "ANKI_NOTE_ID<>\"\"")))
+           (org-map-entries 'org-anki--note-at-point (concat org-anki-prop-note-id "<>\"\""))))
       (org-anki--no-action))))
 
 ;; Stolen from https://github.com/louietan/anki-editor

--- a/org-anki.el
+++ b/org-anki.el
@@ -476,7 +476,7 @@ be removed from the Anki app, return actions that do that."
        ;; added note
        ((equal "addNote" action-value)
         (save-excursion
-          (goto-char (marker-position (org-anki--note-marker note)))
+          (goto-char (org-anki--note-marker note))
           (org-set-property org-anki-prop-note-id (number-to-string result))))
        ;; update note: do nothing but message success
        ((equal "updateNoteFields" action-value)
@@ -596,7 +596,7 @@ be removed from the Anki app, return actions that do that."
            (-map
             (lambda (note)
               (save-excursion
-                (goto-char (marker-position (org-anki--note-marker note)))
+                (goto-char (org-anki--note-marker note))
                 (org-delete-property org-anki-prop-note-id)))
             (reverse notes))
            )

--- a/org-anki.el
+++ b/org-anki.el
@@ -220,10 +220,12 @@ with result."
      :type     type
      :marker   (point-marker))))
 
+;; TODO how to delete markers properly?
 (defun org-anki--delete-markers (notes)
   "Delete the markers held by NOTES."
   (-map (lambda (note)
-          (set-marker (org-anki--note-marker note) nil))
+          (when (org-anki--note-marker note)
+            (set-marker (org-anki--note-marker note) nil)))
         notes))
 
 (defun org-anki--get-fields (type)
@@ -583,7 +585,6 @@ be removed from the Anki app, return actions that do that."
              ;; It's not just one updated note, default to multi;; hit this branch
              (let ((note-action-pairs (-concat additions updates notes-and-tag-actions2))) ;; [(Note, Action)]
                (org-anki--execute-api-actions note-action-pairs))))))
-      (finally (lambda () (org-anki--delete-markers notes)))
       (promise-catch (lambda (reason) (error reason))))))
 
 (defun org-anki--delete-notes_ (notes)
@@ -603,8 +604,7 @@ be removed from the Anki app, return actions that do that."
          (lambda (the-error)
            (org-anki--report-error
             "org-anki-delete-all error: %s"
-            the-error)))))
-  (org-anki--delete-markers notes))
+            the-error))))))
 
 (defun org-anki--get-model-fields (model)
   ;; :: String -> [FieldName]

--- a/org-anki.el
+++ b/org-anki.el
@@ -210,7 +210,8 @@ with result."
        (fields (plist-to-assoc fields-plist))
        ((_ . templates) (assoc type org-anki-field-templates))
        (tags (org-anki--get-tags))
-       (deck (org-anki--find-prop org-anki-prop-deck org-anki-default-deck)))
+       (deck (org-anki--find-prop org-anki-prop-deck org-anki-default-deck))
+       (note-start (point)))
 
     (make-org-anki--note
      :maybe-id (if (stringp maybe-id) (string-to-number maybe-id))
@@ -218,8 +219,8 @@ with result."
      :tags     tags
      :deck     deck
      :type     type
-     :buffer (current-buffer)
-     :point   (point))))
+     :buffer   (current-buffer)
+     :point    note-start)))
 
 (defun org-anki--get-fields (type)
   "Get note field values from entry at point."
@@ -624,7 +625,7 @@ be removed from the Anki app, return actions that do that."
   ;; :: IO ()
   "Synchronize entry at point.
 
-Note: do NOT wrap arount this command if you want to sync multi entries simultaneously.
+Note: do NOT wrap around this command if you want to sync multi entries simultaneously.
 Call `org-anki--sync-notes' instead, or some notes' anki IDs may be missing."
   (interactive)
   (org-anki--sync-notes (cons (org-anki--note-at-point) nil)))


### PR DESCRIPTION
Hi,

I've found that problem the result in this issue: #45 , when we're trying to sync multi notes at the same time, the point field of a note struct could possibly change after inserting some note ids from other addNote replies, so that it fails to find org item using that stale point.

I'm trying to fix it by replacing the point with a marker, it works ok. But a lot of markers in a buffer will make emacs slow, so I delete them afterwards as per docs, after we're done with the sync or delete command. But there is another problem here, it looks like that, in `org-anki--sync-notes` it will delete the markers before the promise-chain.

I'm confused here as I'm not familiar with promise. I'm guessing that the callbacks are called async, but my helper command based on `org-anki-sync-entry` did block, so I don't know how it works under the hood. And my helper command is like:

```elisp
(defun w/org-anki-sync-subentries ()
  "Sync all subentries of the current entry at point.

Also respect `org-anki-skip-function'."
  (interactive)
  (save-excursion
    (let* ((next-level (1+ (org-current-level))))
      (org-map-entries (lambda ()
                         (when (and t
                                    (= next-level (org-element-property :level (org-element-at-point))))
                           (org-anki-sync-entry)))
                       nil
                       'tree
                       org-anki-skip-function))))
```

What's the proper way to delete the markers correctly and safely?