### PR TITLE
support deck names containing spaces

### DIFF
--- a/org-anki.el
+++ b/org-anki.el
@@ -787,7 +787,7 @@ Pandoc is required to be installed."
     (org-anki-connect-request
      (org-anki--body
       "findNotes"
-      `(("query" . ,(concat "deck:" name))))
+      `(("query" . ,(format "deck:\"%s\"" name))))
      (lambda (ids)
        (org-anki-connect-request
         (org-anki--body "notesInfo" `(("notes" . ,ids)))


### PR DESCRIPTION
When running `M-x org-anki-import-deck` with a deck name containing spaces, no note would be returned. According to https://docs.ankiweb.net/searching.html#tags-decks-cards-and-notes, the deck name should be enclosed in quotes in such situation.