### PR TITLE
Enable communication with AnkiConnect when authentication key is needed

### DIFF
--- a/org-anki.el
+++ b/org-anki.el
@@ -92,6 +92,18 @@ property"
   :type '(string)
   :group 'org-anki)
 
+(defcustom org-anki-authentication-key nil
+  "Authentication key to pass to AnkiConnect.
+Alternatively, define org-anki-authentication-key-function."
+  :type '(string)
+  :group 'org-anki)
+
+(defcustom org-anki-authentication-key-function nil
+  "Function which produces the authentication key to pass to AnkiConnect.
+Overrides org-anki-authentication-key."
+  :type '(function)
+  :group 'org-anki)
+
 (defcustom org-anki-inherit-tags t
   "Inherit tags, set to nil to turn off."
   :type 'boolean
@@ -139,7 +151,7 @@ customizable by the org-anki-ankiconnnect-listen-address variable.
 
 BODY is the alist json payload, CALLBACK the function to call
 with result."
-  (let ((json (json-encode `(("version" . 6) ,@body))))
+  (let ((json (json-encode `(("version" . 6) ("key" . ,(org-anki--get-authentication-key)) ,@body))))
     (request
       org-anki-ankiconnnect-listen-address
       :type "GET"
@@ -164,6 +176,13 @@ with result."
                    (funcall on-error the-error)
                  (org-anki--report-error "Unhandled error: %s" the-error))
            (funcall on-result the-result))))))))
+
+(defun org-anki--get-authentication-key ()
+  "Get user-defined authentication key (string) from
+org-anki-authentication-key-function or org-anki-authentication-key."
+  (if org-anki-authentication-key-function
+      (funcall org-anki-authentication-key-function)
+    org-anki-authentication-key))
 
 (defun org-anki--get-current-tags (ids)
   ;; :: [Id] -> Promise [[Tag]]


### PR DESCRIPTION
Hello. I found that org-anki could not communicate with AnkiConnect because I use the [authentication key feature of AnkiConnect](https://git.foosoft.net/alex/anki-connect#authentication). When this feature is in use, AnkiConnect requires an additional field, `"key"`, in the request, with the value being the authentication key.

I went ahead and drafted an implementation which introduces 2 new user-customizable variables. The user can either set the authentication key directly in their config:
```emacs-lisp
(customize-set-variable 'org-anki-authentication-key "<my-authentication-key>")
```
or indirectly by defining a function that should be used to fetch the authentication key:
```emacs-lisp
(customize-set-variable 'org-anki-authentication-key-function '(lambda () "<my-authentication-key>"))
```

I'm fairly new to elisp but I think this is sufficient to implement the feature.

Note: AnkiConnect reads the value of `"key"` and validates it against the `"apiKey"` defined in the AnkiConnect addon config. In the default case, AnkiConnect disables the feature by setting `"apiKey"` to null. So, if you try to connect with a non-null `"key"`, then the communication will be rejected. In other words, if you use the authentication feature and then turn it off, you must also remove or nil the `org-anki-authentication-key` setting from your `init.el`.


Thanks for making this great package!

[Edit 2024-01-05: changed link to AnkiConnect readme since it has moved from GitHub to foosoft.net]