### PR TITLE
Added commentary

### DIFF
--- a/org-anki.el
+++ b/org-anki.el
@@ -24,9 +24,8 @@
 
 ;;; Commentary:
 
-;; Minor mode to synchronize org-mode entries to Anki via AnkiConnect.
-;;
-;; See https://github.com/eyeinsky/org-anki for more.
+;; Comprehensive yet minimally-invasive set of commands to for two-way sync of org-mode entries and
+;; Anki notes, including tags, and in either "Basic" or "Cloze" styles, via AnkiConnect and Pandoc.
 
 
 ;;; Code:


### PR DESCRIPTION
Having proper commentary makes the package more attractive and easier to understand in the package manager. Alternatively, perhaps it would be better to maintain the "commentary" section and have the README more version-agnostic? Or, one could export README.org as plaintext and copy it into the commentary section whenever it changes, but this is an annoying maintenance task that makes a mess of the git tree without a good way to automate it.