### PR TITLE
Fix style

### DIFF
--- a/org-anki.el
+++ b/org-anki.el
@@ -91,7 +91,7 @@ This can be used, for example, to add backlinks to cards."
   ;; The sexp value above should be a function from string to string,
   ;; See https://github.com/eyeinsky/org-anki/pull/58 for more.
 
-(defcustom org-anki-ankiconnnect-listen-address "http://127.0.0.1:8765"
+(defcustom org-anki-ankiconnect-listen-address "http://127.0.0.1:8765"
   "The AnkiConnect listening address."
   :type '(string :tag "Address")
   :group 'org-anki)
@@ -155,7 +155,7 @@ Default NAME is \"PROPERTY\", default BUFFER the current buffer."
 (defun org-anki-connect-request (body on-result on-error)
   "Perform HTTP GET request to AnkiConnect.
 Address is customizable by the
-org-anki-ankiconnnect-listen-address variable.
+org-anki-ankiconnect-listen-address variable.
 
 BODY is the alist json payload, ON-RESULT is the function to call
 with the result, and ON-ERROR a function called on errors."
@@ -165,7 +165,7 @@ with the result, and ON-ERROR a function called on errors."
                  ,@(if org-anki-api-key `(("key" . ,org-anki-api-key)))
                  ,@body))))
     (request
-      org-anki-ankiconnnect-listen-address
+      org-anki-ankiconnect-listen-address
       :type "GET"
       :data json
       :headers '(("Content-Type" . "application/json"))

--- a/org-anki.el
+++ b/org-anki.el
@@ -52,17 +52,17 @@
 
 (defcustom org-anki-default-deck nil
   "Default deck name if otherwise unset."
-  :type '(string)
+  :type 'string
   :group 'org-anki)
 
 (defcustom org-anki-default-match nil
-  "Default match used in `org-map-entries` for sync all."
-  :type '(string)
+  "Default match used in `org-map-entries` for sync all." ;???
+  :type '(choice string (const :tag "nil" nil))           ;I have no idea what this option does.
   :group 'org-anki)
 
 (defcustom org-anki-default-note-type "Basic"
-  "Default note type."
-  :type '(string)
+  "Default note type if otherwise unset."
+  :type 'string
   :group 'org-anki)
 
 (defcustom org-anki-model-fields
@@ -71,7 +71,7 @@
     ("Basic (optional reversed card)" "Front" "Back")
     ("NameDescr" "Name" "Descr")
     ("Cloze" "Text" "Extra"))
-  "Default fields for note types.
+  "Model and field names for note types.
 
 Each one is a list, the first item is the model name and the rest are field names."
   :type '(repeat :tag "Types"
@@ -79,7 +79,7 @@ Each one is a list, the first item is the model name and the rest are field name
                        (repeat :tag "Field Names" string)))
   :group 'org-anki)
 
-(defcustom org-anki-field-templates nil
+(defcustom org-anki-field-templates (list) ;more "correct" I think?
   "Templates for transforming certain note fields.
 This can be used, for example, to add backlinks to cards."
   :type '(alist :tag "Model Name"
@@ -102,7 +102,7 @@ This can be used, for example, to add backlinks to cards."
 This AnkiConnect functionality is disabled by default.
 See https://foosoft.net/projects/anki-connect/#authentication for
 more."
-  :type '(string)
+  :type '(choice string (const :tag "Unset" nil))
   :group 'org-anki)
 
 (defcustom org-anki-inherit-tags t
@@ -119,7 +119,8 @@ tags."
   "Function used to skip entries.
 Given as the SKIP argument to `org-map-entries'. See its help for
 how to use it to include or skip an entry from being synced."
-  :type '(function)
+  :type '(sexp)                         ;any expression is allowed, see org-map-entries
+                                        ;documentation
   :group 'org-anki)
 
 (defcustom org-anki-allow-duplicates nil

--- a/org-anki.el
+++ b/org-anki.el
@@ -144,7 +144,7 @@ how to use it to include or skip an entry from being synced."
 ;; Get list of global properties
 ;;
 ;; From:
-;;   https://emacs.stackexchange.com/questions/21713/how-to-get-property-values-from-org-file-headers
+;; https://emacs.stackexchange.com/questions/21713/how-to-get-property-values-from-org-file-headers
 (defun org-anki--global-props (&optional name buffer)
   "Get the plists of global org properties by NAME in BUFFER.
 
@@ -185,7 +185,8 @@ with the result, and ON-ERROR a function called on errors."
       (cl-function
        (lambda (&key error-thrown &allow-other-keys)
          (org-anki--report-error
-          "Can't connect to Anki: is the application running and is AnkiConnect installed?\n\nGot error: %s"
+          "Can't connect to Anki: is the application running\
+ and is AnkiConnect installed?\n\nGot error: %s"
           (cdr error-thrown))))
 
       :success
@@ -197,7 +198,7 @@ with the result, and ON-ERROR a function called on errors."
                (if on-error
                    (funcall on-error the-error)
                  (org-anki--report-error "Unhandled error: %s" the-error))
-           (funcall on-result the-result))))))))
+             (funcall on-result the-result))))))))
 
 (defun org-anki--get-current-tags (ids)
   "Retrieves tags of cards with IDS."
@@ -441,7 +442,8 @@ The search order is:
        (if org-anki-inherit-tags
            (substring-no-properties (or (org-entry-get nil "ALLTAGS") ""))
          (org-entry-get nil "TAGS"))
-       global-tags)) ":" t)))
+       global-tags))
+    ":" t)))
 
 ;;; Cloze
 
@@ -569,8 +571,10 @@ The search order is:
                      (t                              (cons :left note))))
                   notes))
                 ((new . existing) new-and-existing) ;; [Note]
-                (additions (--map (cons it (org-anki--create-note-single it)) new))      ;; [(Note, Action)]
-                (updates   (--map (cons it (org-anki--update-note-single it)) existing)) ;; [(Note, Action)]
+                (additions (--map (cons it (org-anki--create-note-single it)) new))
+                ;; [(Note, Action)]
+                (updates   (--map (cons it (org-anki--update-note-single it)) existing))
+                ;; [(Note, Action)]
 
                 ;; Calculate added and removed tags
                 (notes-and-tag-actions ;; [(Note, [Action])]
@@ -612,7 +616,8 @@ The search order is:
                        (org-anki--execute-api-actions notes-and-tag-actions2)))
 
                ;; It's not just one updated note, default to multi
-               (let ((note-action-pairs (-concat additions updates notes-and-tag-actions2))) ;; [(Note, Action)]
+               (let ((note-action-pairs (-concat additions updates notes-and-tag-actions2)))
+                 ;; [(Note, Action)]
                  (org-anki--execute-api-actions note-action-pairs))))))
         (promise-catch (lambda (reason) (error reason))))))
 

--- a/org-anki.el
+++ b/org-anki.el
@@ -74,45 +74,56 @@
   "Default fields for note types.
 
 Each one is a list, the first item is the model name and the rest are field names."
-  :type '(repeat (list (repeat string)))
+  :type '(repeat :tag "Types"
+                 (list (string :tag "Model Name")
+                       (repeat :tag "Field Names" string)))
   :group 'org-anki)
 
 (defcustom org-anki-field-templates nil
-  "Default templates for note fields."
-  :type '(alist
-          :key-type string
-          :value-type (alist
-                       :key-type string
-                       :value-type sexp))
+  "Templates for transforming certain note fields.
+This can be used, for example, to add backlinks to cards."
+  :type '(alist :tag "Model Name"
+          :key-type string :tag "Field Name"
+          :value-type (alist :tag "Formatting Function"
+                       :key-type string :tag "Format String" ;What is this, really???
+                       :value-type sexp :tag "Conversion Function"))
   :group 'org-anki)
   ;; The sexp value above should be a function from string to string,
   ;; See https://github.com/eyeinsky/org-anki/pull/58 for more.
 
 (defcustom org-anki-ankiconnnect-listen-address "http://127.0.0.1:8765"
   "The AnkiConnect listening address."
-  :type '(string)
+  :type '(string :tag "Address")
   :group 'org-anki)
 
 (defcustom org-anki-api-key nil
   "API key to authenticate to AnkiConnect.
-See https://foosoft.net/projects/anki-connect/#authentication for more."
+
+This AnkiConnect functionality is disabled by default.
+See https://foosoft.net/projects/anki-connect/#authentication for
+more."
   :type '(string)
   :group 'org-anki)
 
 (defcustom org-anki-inherit-tags t
-  "Inherit tags, set to nil to turn off."
-  :type 'boolean
+  "Tag inheritance for Anki notes. Set to nil to turn off.
+
+By default, org headings inherit tags from their parents. If this
+setting is t, the created Anki notes will have these inherited
+tags."
+  :type '(choice (const :tag "Inherit" t)
+                 (const :tag "Do Not Inherit" nil))
   :group 'org-anki)
 
 (defcustom org-anki-skip-function nil
   "Function used to skip entries.
-Given as the SKIP argument to `org-map-entries', see its help for
+Given as the SKIP argument to `org-map-entries'. See its help for
 how to use it to include or skip an entry from being synced."
   :type '(function)
   :group 'org-anki)
 
 (defcustom org-anki-allow-duplicates nil
-  "Allow duplicates."
+  "Allow duplicates."                   ;Duplicate Anki or Org notes? Both?
   :type '(choice (const :tag "Yes" t)
                  (const :tag "No" nil))
   :group 'org-anki)

--- a/org-anki.el
+++ b/org-anki.el
@@ -715,7 +715,8 @@ With PREFIX, include subdirectories."
   ;; :: Maybe Buffer -> IO ()
   (interactive)
   (let* ((buffer-name_ (or buffer (buffer-name)))
-         (prompt (format "Are you sure you want to delete all notes in buffer '%s' from Anki?" buffer-name_)))
+         (prompt (format "Are you sure you want to delete all notes in buffer '%s' from Anki?"
+                         buffer-name_)))
     (if (y-or-n-p prompt)
         (with-current-buffer buffer-name_
           (org-anki--delete-notes_

--- a/org-anki.el
+++ b/org-anki.el
@@ -50,18 +50,28 @@
 
 ;; Customizable variables
 
-(defcustom org-anki-default-deck nil
-  "Default deck name if otherwise unset."
+(defcustom org-anki-default-deck "Org Entries"
+  "Default deck name if otherwise unset.
+
+Deck names can also be set via the ANKI_DECK org property."
   :type 'string
   :group 'org-anki)
 
 (defcustom org-anki-default-match nil
-  "Default match used in `org-map-entries` for sync all." ;???
-  :type '(choice string (const :tag "nil" nil))           ;I have no idea what this option does.
+  "If non-nil, applies a default filter to `org-anki-sync-all'.
+
+Specifically, this string is used as the MATCH argument in the
+command's calls to `org-map-entries' if not set via the
+ANKI-MATCH org property."
+  :type '(choice string (const :tag "nil" nil))
   :group 'org-anki)
 
 (defcustom org-anki-default-note-type "Basic"
-  "Default note type if otherwise unset."
+  "Default note type if otherwise unset.
+
+Note types also can be set via the formatting of the
+note (Basic by default, Cloze if cloze formatting is detected) or
+via the ANKI_NOTE_TYPE org property."
   :type 'string
   :group 'org-anki)
 


### PR DESCRIPTION
This PR fixes a lot of docstrings to match elisp's conventions, adds a default-default deck name, fits the code to a 100-char width, and fixes a typo in a symbol name.