### PR TITLE
Allow use of hierarchical tags

### DIFF
--- a/README.org
+++ b/README.org
@@ -14,7 +14,9 @@ card front and content is the back.[fn:how] If the heading has Cloze
 syntax (={{...}}=) then the heading is used to create both the
 question and the answer, and content of the org entry is not used.
 
-Tags are also synchronized.
+Tags are also synchronized; hierarchical tags can be treated by customizing
+=org-anki-treat-hierarchical-tags= with a string such as =__= that is used in
+the org-file to represent Anki's separator =::= for hierarchical tags.
 
 See [[/example/example.org][example.org]] and the [[/example/][resulting screenshots]] for how the cards look
 after being synced to Anki.

--- a/org-anki.el
+++ b/org-anki.el
@@ -438,7 +438,7 @@ be removed from the Anki app, return actions that do that."
                  ":" t))))
      (if org-anki-treat-hierarchical-tags
          (mapcar (lambda (tag)
-                   (replace-string org-anki-treat-hierarchical-tags "::" tag))
+                   (replace-regexp-in-string org-anki-treat-hierarchical-tags "::" tag))
                  tags)
        tags))))
 
@@ -806,7 +806,7 @@ syntax."
     (if tags
         (let ((processed-tags (if org-anki-treat-hierarchical-tags
                                   (mapcar (lambda (tag)
-                                            (replace-string "::" org-anki-treat-hierarchical-tags tag))
+                                            (replace-regexp-in-string "::" org-anki-treat-hierarchical-tags tag))
                                           tags)
                                 tags)))
           (insert (concat " :" (mapconcat 'identity processed-tags ":") ":")))))


### PR DESCRIPTION
This PR introduces a configurable variable `org-anki-treat-hierarchical-tags`. If set to a string such as '__', this string will be used to represent Anki's separator '::' used in hierarchical tags -in org-files:

- when converting an org node into a note, for each found tag, the string contained in `org-anki-treat-hierarchical-tags` is replaced with `::`
- upon writing a note imported from Anki via deck-import, `::` is replaced with the contents of `org-anki-treat-hierarchical-tags`

If the variable `org-anki-treat-hierarchical-tags` remains unconfigured, org-anki behaves exactly as before.